### PR TITLE
Fix some comments on gANDI, iANDI, lANDI and sANDI

### DIFF
--- a/andi/gandi.js
+++ b/andi/gandi.js
@@ -1,5 +1,5 @@
 //==========================================//
-//gANDI: graphics ANDI 						//
+//gANDI: graphics/images ANDI 				//
 //Created By Social Security Administration //
 //==========================================//
 function init_module(){

--- a/andi/iandi.js
+++ b/andi/iandi.js
@@ -1,5 +1,5 @@
 //=============================================//
-//fANDI: focusable elements ANDI (default mode)//
+//iANDI: iFrames ANDI                          //
 //Created By Social Security Administration	   //
 //=============================================//
 function init_module(){
@@ -9,7 +9,7 @@ var iandiVersionNumber = "3.0.1";
 //create iANDI instance
 var iANDI = new AndiModule(iandiVersionNumber,"i");
 
-//This function will analyze the test page for focusable element related markup relating to accessibility
+//This function will analyze the test page for iFrame related markup relating to accessibility
 iANDI.analyze = function(){
 	$(TestPageData.allVisibleElements).each(function(){
 		if($(this).is("iframe")){

--- a/andi/ie8.css
+++ b/andi/ie8.css
@@ -8,7 +8,7 @@
 #ANDI508-testPage.gANDI508-testPage.gANDI508-fadeInline .ANDI508-element img
 	{filter: alpha(opacity=30) !important; /*no support for opacity*/}
 	
-#ANDI508-testPage.gANDI508-testPage.gANDI508-hideBackground .lANDI508-background
+#ANDI508-testPage.gANDI508-testPage.gANDI508-hideBackground .gANDI508-background
 	{filter: alpha(opacity=30) !important; /*no support for opacity*/}
 
 #ANDI508 #ANDI508-moduleMenu button:hover,

--- a/andi/landi.js
+++ b/andi/landi.js
@@ -1,5 +1,5 @@
 //==========================================//
-//lANDI: links ANDI 						//
+//lANDI: links/buttons ANDI 				//
 //Created By Social Security Administration //
 //==========================================//
 function init_module(){

--- a/andi/sandi.js
+++ b/andi/sandi.js
@@ -371,7 +371,7 @@ sANDI.results = function(){
 		return false;
 	});
 
-	//Define the lang attributes button
+	//Define the role attributes button
 	$("#ANDI508-roleAttributes-button").click(function(){
 		if($(this).attr("aria-pressed") == "false"){
 			andiOverlay.overlayButton_on("overlay",$(this));


### PR DESCRIPTION
Fixed:

- The text for gANDI from "gANDI: graphics ANDI" to "gANDI: graphics/images ANDI"
- The text for iANDI from: "fANDI: focusable elements ANDI (default mode)" to "iANDI: iFrames ANDI"
- Fixed comment from iANDI on line 12 by changing "focuable element" to iFrame
- Fixed comment on lANDI from: "lANDI: links ANDI" to "lANDI: links/buttons ANDI"
- Fixed comment on sANDI on line 374 by changing "lang" to "role"
- 